### PR TITLE
build: Add an option to block non-enforcing builds

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -855,6 +855,11 @@ INTERNAL_RECOVERYIMAGE_ARGS := \
 
 # Assumes this has already been stripped
 ifdef BOARD_KERNEL_CMDLINE
+  ifdef BUILD_ENFORCE_SELINUX
+      ifneq (,$(filter androidboot.selinux=permissive androidboot.selinux=disabled, $(BOARD_KERNEL_CMDLINE)))
+          $(error "Trying to apply non-default selinux settings. Aborting")
+      endif
+  endif
   INTERNAL_RECOVERYIMAGE_ARGS += --cmdline "$(BOARD_KERNEL_CMDLINE)"
 endif
 ifdef BOARD_KERNEL_BASE


### PR DESCRIPTION
Prevent accidental build of test configurations. Hopping back and
forth between states (especially disabled) leaves a mess in the
filesystems, and we want to try to ensure published builds go out
enforcing.

Change-Id: I2206975968de421dec842f49b02490fa85ca9f3b