### PR TITLE
Add support for OSX up to 10.10 and CLI Tools

### DIFF
--- a/core/combo/HOST_darwin-x86.mk
+++ b/core/combo/HOST_darwin-x86.mk
@@ -37,11 +37,14 @@ $(combo_2nd_arch_prefix)HOST_TOOLCHAIN_PREFIX := $($(combo_2nd_arch_prefix)HOST_
 ifneq (,$(strip $(wildcard $($(combo_2nd_arch_prefix)HOST_TOOLCHAIN_PREFIX)-gcc)))
 $(combo_2nd_arch_prefix)HOST_CC  := $($(combo_2nd_arch_prefix)HOST_TOOLCHAIN_PREFIX)-gcc
 $(combo_2nd_arch_prefix)HOST_CXX := $($(combo_2nd_arch_prefix)HOST_TOOLCHAIN_PREFIX)-g++
-ifeq ($(mac_sdk_version),10.8)
-# Mac SDK 10.8 no longer has stdarg.h, etc
-host_toolchain_header := $($(combo_2nd_arch_prefix)HOST_TOOLCHAIN_ROOT)/lib/gcc/i686-apple-darwin$(gcc_darwin_version)/4.2.1/include
+
+ifeq ($(mac_sdk_version), $(filter $(mac_sdk_version), 10.8 10.9 10.10))
+# Mac SDK 10.8 and later does not have stdarg.h, etc
+host_toolchain_header := $(HOST_TOOLCHAIN_ROOT)/lib/gcc/i686-apple-darwin$(gcc_darwin_version)/4.2.1/include
 $(combo_2nd_arch_prefix)HOST_GLOBAL_CFLAGS += -isystem $(host_toolchain_header)
-endif
+$(combo_2nd_arch_prefix)HOST_GLOBAL_CPPFLAGS += -isystem $(mac_sdk_root)/usr/include/c++/4.2.1
+endif # $(mac_sdk_version)
+
 else
 $(combo_2nd_arch_prefix)HOST_CC := gcc
 $(combo_2nd_arch_prefix)HOST_CXX := g++
@@ -66,7 +69,7 @@ $(combo_2nd_arch_prefix)HOST_JNILIB_SUFFIX := .jnilib
 $(combo_2nd_arch_prefix)HOST_GLOBAL_CFLAGS += \
     -include $(call select-android-config-h,darwin-x86)
 
-ifneq ($(filter 10.7 10.7.% 10.8 10.8.%, $(build_mac_version)),)
+ifneq ($(filter 10.7 10.7.% 10.8 10.8.% 10.9 10.9.% 10.10 10.10.%, $(build_mac_version)),)
        $(combo_2nd_arch_prefix)HOST_RUN_RANLIB_AFTER_COPYING := false
 else
        $(combo_2nd_arch_prefix)HOST_RUN_RANLIB_AFTER_COPYING := true

--- a/core/combo/HOST_darwin-x86_64.mk
+++ b/core/combo/HOST_darwin-x86_64.mk
@@ -37,11 +37,14 @@ HOST_TOOLCHAIN_PREFIX := $(HOST_TOOLCHAIN_ROOT)/bin/i686-apple-darwin$(gcc_darwi
 ifneq (,$(strip $(wildcard $(HOST_TOOLCHAIN_PREFIX)-gcc)))
 HOST_CC  := $(HOST_TOOLCHAIN_PREFIX)-gcc
 HOST_CXX := $(HOST_TOOLCHAIN_PREFIX)-g++
-ifeq ($(mac_sdk_version),10.8)
-# Mac SDK 10.8 no longer has stdarg.h, etc
+
+ifeq ($(mac_sdk_version), $(filter $(mac_sdk_version), 10.8 10.9 10.10))
+# Mac SDK 10.8 and later does not have stdarg.h, etc
 host_toolchain_header := $(HOST_TOOLCHAIN_ROOT)/lib/gcc/i686-apple-darwin$(gcc_darwin_version)/4.2.1/include
 HOST_GLOBAL_CFLAGS += -isystem $(host_toolchain_header)
-endif
+HOST_GLOBAL_CPPFLAGS += -isystem $(mac_sdk_root)/usr/include/c++/4.2.1
+endif # $(mac_sdk_version)
+
 else
 HOST_CC := gcc
 HOST_CXX := g++
@@ -65,7 +68,7 @@ HOST_JNILIB_SUFFIX := .jnilib
 HOST_GLOBAL_CFLAGS += \
     -include $(call select-android-config-h,darwin-x86)
 
-ifneq ($(filter 10.7 10.7.% 10.8 10.8.%, $(build_mac_version)),)
+ifneq ($(filter 10.7 10.7.% 10.8 10.8.% 10.9 10.9.% 10.10 10.10.%, $(build_mac_version)),)
        HOST_RUN_RANLIB_AFTER_COPYING := false
 else
        HOST_RUN_RANLIB_AFTER_COPYING := true

--- a/core/combo/mac_version.mk
+++ b/core/combo/mac_version.mk
@@ -9,17 +9,19 @@ ifndef build_mac_version
 
 build_mac_version := $(shell sw_vers -productVersion)
 
-mac_sdk_versions_supported :=  10.6 10.7 10.8
+# Caution: Do not add 10.10 to this list until the prebuilts/darwin-x86 toolchains are updated.
+#          In the meantime, setting mac_sdk_version to 10.9 works on Yosemite (verified on 10.10.1).
+mac_sdk_versions_supported := 10.6 10.7 10.8 10.9
 ifneq ($(strip $(MAC_SDK_VERSION)),)
 mac_sdk_version := $(MAC_SDK_VERSION)
 ifeq ($(filter $(mac_sdk_version),$(mac_sdk_versions_supported)),)
 $(warning ****************************************************************)
-$(warning * MAC_SDK_VERSION $(MAC_SDK_VERSION) isn't one of the supported $(mac_sdk_versions_supported))
+$(warning * MAC_SDK_VERSION $(MAC_SDK_VERSION) isn\'t one of the supported $(mac_sdk_versions_supported))
 $(warning ****************************************************************)
 $(error Stop.)
 endif
 else
-mac_sdk_versions_installed := $(shell xcodebuild -showsdks | grep macosx | sort | sed -e "s/.*macosx//g")
+mac_sdk_versions_installed := $(shell xcodebuild -showsdks 2> /dev/null | grep macosx | sort | sed -e "s/.*macosx//g")
 mac_sdk_version := $(firstword $(filter $(mac_sdk_versions_installed), $(mac_sdk_versions_supported)))
 ifeq ($(mac_sdk_version),)
 mac_sdk_version := $(firstword $(mac_sdk_versions_supported))
@@ -27,6 +29,18 @@ endif
 endif
 
 mac_sdk_path := $(shell xcode-select -print-path)
+
+ifeq ($(strip "$(mac_sdk_path)"), "/Library/Developer/CommandLineTools")
+# Accept any modern version of Apple Command Line Tools
+mac_sdk_root := /
+
+# Override mac_sdk_version with build_mac_version (aka the version of the OSX host), but assume the latest
+# supported mac_sdk_version if the build_mac_version is not recognized.
+mac_sdk_version := $(shell echo $(build_mac_version) | cut -d '.' -f 1,2)
+ifeq ($(filter $(mac_sdk_version),$(mac_sdk_versions_supported)),)
+mac_sdk_version := $(lastword $(mac_sdk_versions_supported))
+endif
+else
 # try /Applications/Xcode*.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.?.sdk
 #  or /Volume/Xcode/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.?.sdk
 mac_sdk_root := $(mac_sdk_path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(mac_sdk_version).sdk
@@ -40,6 +54,7 @@ $(warning * Can not find SDK $(mac_sdk_version) at $(mac_sdk_root))
 $(warning *****************************************************)
 $(error Stop.)
 endif
+endif # $(mac_sdk_path)
 
 ifeq ($(mac_sdk_version),10.6)
   gcc_darwin_version := 10


### PR DESCRIPTION
- Support using OSX versions 10.9 and 10.10 as the compilation host.
  Please note that the prebuilt darwin-x86 gcc is missing an upstream
  patch that properly identifies 10.10 as newer than 10.2, which
  restricts mac_sdk_versions_supported to 10.9.
- Support using Xcode Command Line Tools, waiving the requirement for
  installing the full Xcode development suite for 600k worth of C++
  headers.

These build modifications have been verified by successfully compiling a
cm12-hammerhead image from scratch on a OSX Yosemite 10.10.1 host with
Xcode Command Line Tools 6.1.1 installed.

Change-Id: Id1741ef583d186eb6a42093e5111431ae7b08a2c